### PR TITLE
Fix default assignment to use env variables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,16 +1,19 @@
 AllCops:
   TargetRubyVersion: 3.0
 
-
 Metrics/AbcSize:
   Max: 26
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"
 
 Metrics/MethodLength:
   Max: 20
 
 Style/Documentation:
   Exclude:
-    - 'lib/mailcat.rb'
+    - "lib/mailcat.rb"
 
 Style/StringLiterals:
   Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailcat (0.1.1)
+    mailcat (0.1.2)
       activesupport (>= 6.0.0)
 
 GEM

--- a/lib/mailcat.rb
+++ b/lib/mailcat.rb
@@ -10,6 +10,14 @@ module Mailcat
 
   include ::ActiveSupport::Configurable
 
-  config_accessor :mailcat_api_key, default: ENV["MAILCAT_API_KEY"]
-  config_accessor :mailcat_url, default: ENV["MAILCAT_URL"]
+  config_accessor :mailcat_api_key, default: -> { ENV["MAILCAT_API_KEY"] }
+  config_accessor :mailcat_url, default: -> { ENV["MAILCAT_URL"] }
+
+  def self.mailcat_api_key_raw
+    config.mailcat_api_key.is_a?(Proc) ? config.mailcat_api_key.call : config.mailcat_api_key
+  end
+
+  def self.mailcat_url_raw
+    config.mailcat_url.is_a?(Proc) ? config.mailcat_url.call : config.mailcat_url
+  end
 end

--- a/lib/mailcat/delivery_method.rb
+++ b/lib/mailcat/delivery_method.rb
@@ -21,7 +21,7 @@ module Mailcat
       Net::HTTP.start(emails_uri.hostname, emails_uri.port, use_ssl: emails_uri.scheme == "https") do |http|
         req = Net::HTTP::Post.new(emails_uri)
         req["Content-Type"] = "application/json"
-        req["X-Api-Key"] = Mailcat.config.mailcat_api_key
+        req["X-Api-Key"] = Mailcat.mailcat_api_key_raw
         email_body = {
           from: mail.from.first,
           to: mail.to,
@@ -62,7 +62,7 @@ module Mailcat
 
       req = Net::HTTP::Post.new(direct_uploads_uri)
       req["Content-Type"] = "application/json"
-      req["X-Api-Key"] = Mailcat.config.mailcat_api_key
+      req["X-Api-Key"] = Mailcat.mailcat_api_key_raw
       req.body = {
         blob: {
           filename: attachment.filename,
@@ -82,11 +82,11 @@ module Mailcat
     end
 
     def emails_uri
-      @emails_uri ||= URI("#{Mailcat.config.mailcat_url}/api/emails")
+      @emails_uri ||= URI("#{Mailcat.mailcat_url_raw}/api/emails")
     end
 
     def direct_uploads_uri
-      @direct_uploads_uri ||= URI("#{Mailcat.config.mailcat_url}/api/direct_uploads")
+      @direct_uploads_uri ||= URI("#{Mailcat.mailcat_url_raw}/api/direct_uploads")
     end
 
     def attachment_tempfile(attachment)

--- a/lib/mailcat/version.rb
+++ b/lib/mailcat/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mailcat
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/mailcat_spec.rb
+++ b/spec/mailcat_spec.rb
@@ -4,4 +4,34 @@ RSpec.describe Mailcat do
   it "has a version number" do
     expect(Mailcat::VERSION).not_to be nil
   end
+
+  describe "environment variable loader" do
+    context "when using the default environment variables" do
+      before do
+        stub_const("ENV", ENV.to_h.merge(
+                            "MAILCAT_API_KEY" => "spec_key",
+                            "MAILCAT_URL" => "https://spec-url.com"
+                          ))
+      end
+
+      it "uses ENV defaults if not explicitly set" do
+        expect(Mailcat.mailcat_api_key_raw).to eq("spec_key")
+        expect(Mailcat.mailcat_url_raw).to eq("https://spec-url.com")
+      end
+    end
+
+    context "when explicitly set" do
+      before do
+        described_class.configure do |config|
+          config.mailcat_api_key = "explicit_key"
+          config.mailcat_url = "https://explicit-url.com"
+        end
+      end
+
+      it "uses explicitly set values" do
+        expect(Mailcat.mailcat_api_key_raw).to eq("explicit_key")
+        expect(Mailcat.mailcat_url_raw).to eq("https://explicit-url.com")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description

The default values for `mailcat_api_key` and `mailcat_url` were returning `nil` because the env variables hadn’t been loaded yet. I changed the default to a proc so they’re only evaluated when needed, ensuring the env variables are accessible by that time.

---

### Notes

N/A