### PR TITLE
Replace deprecated ActiveSupport::Configurable with explicit Configuration class

### DIFF
--- a/lib/mailcat.rb
+++ b/lib/mailcat.rb
@@ -3,23 +3,26 @@
 require "mailcat/delivery_method"
 require "mailcat/railtie" if defined?(Rails::Railtie)
 require "mailcat/version"
-require "active_support/core_ext/module/attribute_accessors"
 
 module Mailcat
   class Error < StandardError; end
 
-  mattr_accessor :mailcat_api_key, default: -> { ENV["MAILCAT_API_KEY"] }
-  mattr_accessor :mailcat_url, default: -> { ENV["MAILCAT_URL"] }
+  class Configuration
+    attr_accessor :mailcat_api_key, :mailcat_url
 
-  def self.configure
-    yield self
+    def initialize
+      @mailcat_api_key = ENV["MAILCAT_API_KEY"]
+      @mailcat_url     = ENV["MAILCAT_URL"]
+    end
   end
 
-  def self.mailcat_api_key_raw
-    mailcat_api_key.is_a?(Proc) ? mailcat_api_key.call : mailcat_api_key
-  end
+  class << self
+    def config
+      @config ||= Configuration.new
+    end
 
-  def self.mailcat_url_raw
-    mailcat_url.is_a?(Proc) ? mailcat_url.call : mailcat_url
+    def configure
+      yield config
+    end
   end
 end

--- a/lib/mailcat.rb
+++ b/lib/mailcat.rb
@@ -3,21 +3,23 @@
 require "mailcat/delivery_method"
 require "mailcat/railtie" if defined?(Rails::Railtie)
 require "mailcat/version"
-require "active_support"
+require "active_support/core_ext/module/attribute_accessors"
 
 module Mailcat
   class Error < StandardError; end
 
-  include ::ActiveSupport::Configurable
+  mattr_accessor :mailcat_api_key, default: -> { ENV["MAILCAT_API_KEY"] }
+  mattr_accessor :mailcat_url, default: -> { ENV["MAILCAT_URL"] }
 
-  config_accessor :mailcat_api_key, default: -> { ENV["MAILCAT_API_KEY"] }
-  config_accessor :mailcat_url, default: -> { ENV["MAILCAT_URL"] }
+  def self.configure
+    yield self
+  end
 
   def self.mailcat_api_key_raw
-    config.mailcat_api_key.is_a?(Proc) ? config.mailcat_api_key.call : config.mailcat_api_key
+    mailcat_api_key.is_a?(Proc) ? mailcat_api_key.call : mailcat_api_key
   end
 
   def self.mailcat_url_raw
-    config.mailcat_url.is_a?(Proc) ? config.mailcat_url.call : config.mailcat_url
+    mailcat_url.is_a?(Proc) ? mailcat_url.call : mailcat_url
   end
 end

--- a/lib/mailcat/delivery_method.rb
+++ b/lib/mailcat/delivery_method.rb
@@ -3,11 +3,7 @@
 module Mailcat
   # Rails delivery_method for Mailcat.
   class DeliveryMethod
-    attr_accessor :settings
-
-    def initialize(...)
-      self.settings = Mailcat.config
-    end
+    def initialize(settings = {}); end
 
     def deliver!(mail)
       send_to_mailcat(mail)

--- a/lib/mailcat/delivery_method.rb
+++ b/lib/mailcat/delivery_method.rb
@@ -17,7 +17,7 @@ module Mailcat
       Net::HTTP.start(emails_uri.hostname, emails_uri.port, use_ssl: emails_uri.scheme == "https") do |http|
         req = Net::HTTP::Post.new(emails_uri)
         req["Content-Type"] = "application/json"
-        req["X-Api-Key"] = Mailcat.mailcat_api_key_raw
+        req["X-Api-Key"] = Mailcat.config.mailcat_api_key
         email_body = {
           from: mail.from.first,
           to: mail.to,
@@ -58,7 +58,7 @@ module Mailcat
 
       req = Net::HTTP::Post.new(direct_uploads_uri)
       req["Content-Type"] = "application/json"
-      req["X-Api-Key"] = Mailcat.mailcat_api_key_raw
+      req["X-Api-Key"] = Mailcat.config.mailcat_api_key
       req.body = {
         blob: {
           filename: attachment.filename,
@@ -78,11 +78,11 @@ module Mailcat
     end
 
     def emails_uri
-      @emails_uri ||= URI("#{Mailcat.mailcat_url_raw}/api/emails")
+      @emails_uri ||= URI("#{Mailcat.config.mailcat_url}/api/emails")
     end
 
     def direct_uploads_uri
-      @direct_uploads_uri ||= URI("#{Mailcat.mailcat_url_raw}/api/direct_uploads")
+      @direct_uploads_uri ||= URI("#{Mailcat.config.mailcat_url}/api/direct_uploads")
     end
 
     def attachment_tempfile(attachment)

--- a/spec/mailcat_spec.rb
+++ b/spec/mailcat_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Mailcat do
   describe "configuration" do
     context "when using the default environment variables" do
       before do
-        Mailcat.instance_variable_set(:@config, nil)
         stub_const("ENV", ENV.to_h.merge(
                             "MAILCAT_API_KEY" => "spec_key",
                             "MAILCAT_URL" => "https://spec-url.com"
@@ -23,7 +22,6 @@ RSpec.describe Mailcat do
 
     context "when explicitly set" do
       before do
-        Mailcat.instance_variable_set(:@config, nil)
         described_class.configure do |config|
           config.mailcat_api_key = "explicit_key"
           config.mailcat_url = "https://explicit-url.com"

--- a/spec/mailcat_spec.rb
+++ b/spec/mailcat_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe Mailcat do
     expect(Mailcat::VERSION).not_to be nil
   end
 
-  describe "environment variable loader" do
+  describe "configuration" do
     context "when using the default environment variables" do
       before do
+        Mailcat.instance_variable_set(:@config, nil)
         stub_const("ENV", ENV.to_h.merge(
                             "MAILCAT_API_KEY" => "spec_key",
                             "MAILCAT_URL" => "https://spec-url.com"
@@ -15,13 +16,14 @@ RSpec.describe Mailcat do
       end
 
       it "uses ENV defaults if not explicitly set" do
-        expect(Mailcat.mailcat_api_key_raw).to eq("spec_key")
-        expect(Mailcat.mailcat_url_raw).to eq("https://spec-url.com")
+        expect(Mailcat.config.mailcat_api_key).to eq("spec_key")
+        expect(Mailcat.config.mailcat_url).to eq("https://spec-url.com")
       end
     end
 
     context "when explicitly set" do
       before do
+        Mailcat.instance_variable_set(:@config, nil)
         described_class.configure do |config|
           config.mailcat_api_key = "explicit_key"
           config.mailcat_url = "https://explicit-url.com"
@@ -29,8 +31,8 @@ RSpec.describe Mailcat do
       end
 
       it "uses explicitly set values" do
-        expect(Mailcat.mailcat_api_key_raw).to eq("explicit_key")
-        expect(Mailcat.mailcat_url_raw).to eq("https://explicit-url.com")
+        expect(Mailcat.config.mailcat_api_key).to eq("explicit_key")
+        expect(Mailcat.config.mailcat_url).to eq("https://explicit-url.com")
       end
     end
   end


### PR DESCRIPTION
`ActiveSupport::Configurable` was deprecated in Rails 8.1 and will be removed in Rails 8.2.

This replaces it with an explicit `Configuration` class, which is the standard pattern for Ruby gems.

**Changes:**
- Add `Mailcat::Configuration` class with `attr_accessor` for `mailcat_api_key` and `mailcat_url`
- ENV defaults are set in `Configuration#initialize`
- Add `Mailcat.config` and `Mailcat.configure` class methods
- Update `DeliveryMethod` to use `Mailcat.config.*` instead of `Mailcat.*_raw`
- Drop `active_support/core_ext/module/attribute_accessors` require (no longer needed)

The public configure API is unchanged:

```ruby
Mailcat.configure do |config|
  config.mailcat_api_key = "..."
  config.mailcat_url = "..."
end
```